### PR TITLE
feat(products): add POST /products/:id/variants endpoint

### DIFF
--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Param, NotFoundException, Query, Post, Body, Patch, UseGuards } from '@nestjs/common';
 import { ProductsService, UpdateProductDto } from './products.service';
-import { CreateProductDto } from './dto/create-product.dto';
+import { CreateProductDto, CreateVariantDto } from './dto/create-product.dto';
 import { CreateBrandDto } from './dto/create-brand.dto';
-import { ApiOperation, ApiResponse, ApiTags, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags, ApiParam, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { AllProductsResponseDto, SingleProductResponseDto } from './dto/product-response.dto';
 import { PaginationQueryDto } from '../../common/dto/pagination.dto';
 import { PricingRulesService } from './pricing-rules.service';
@@ -123,6 +123,23 @@ export class ProductsController {
     return {
       message: 'Berhasil memperbarui produk',
       data: result,
+    };
+  }
+
+  @Post(':id/variants')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('MANAGER')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create new variant', description: 'Adds a new variant to an existing product.' })
+  @ApiParam({ name: 'id', description: 'Unique identifier of the product' })
+  @ApiBody({ type: CreateVariantDto })
+  @ApiResponse({ status: 201, description: 'Variant created successfully' })
+  @ApiResponse({ status: 404, description: 'Product not found' })
+  async createVariant(@Param('id') id: string, @Body() dto: CreateVariantDto) {
+    const variant = await this.productsService.createVariant(id, dto);
+    return {
+      message: 'Berhasil menambahkan varian baru',
+      data: variant,
     };
   }
 }

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -2,10 +2,11 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { DRIZZLE_DB } from '../../common/database/database.module';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../../db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql, desc } from 'drizzle-orm';
 import { ConfigService } from '@nestjs/config';
 import { CreateProductDto } from './dto/create-product.dto';
 import { CreateBrandDto } from './dto/create-brand.dto';
+import { generateNextSku } from '../../lib/sku-generator.util';
 
 export class UpdateProductDto {
   name?: string;
@@ -231,5 +232,38 @@ export class ProductsService {
       })
       .returning();
     return brand;
+  }
+
+  async createVariant(productId: string, dto: { package: string; price: number; initialStock?: number; sku?: string; sizeInGram?: number }) {
+    return await this.db.transaction(async (tx) => {
+      const product = await tx.query.products.findFirst({
+        where: eq(schema.products.id, productId),
+      });
+
+      if (!product) {
+        throw new NotFoundException(`Produk dengan ID ${productId} tidak ditemukan`);
+      }
+
+      const lastVariant = await tx.query.productVariants.findFirst({
+        where: eq(schema.productVariants.productId, productId),
+        orderBy: [desc(schema.productVariants.createdAt)],
+      });
+
+      const sku = dto.sku || generateNextSku(lastVariant?.sku || null);
+
+      const [variant] = await tx
+        .insert(schema.productVariants)
+        .values({
+          productId,
+          package: dto.package as typeof schema.productVariantLabelEnum.enumValues[number],
+          price: dto.price,
+          stock: dto.initialStock ?? 0,
+          sku,
+          sizeInGram: dto.sizeInGram,
+        })
+        .returning();
+
+      return variant;
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **New endpoint**: `POST /products/:id/variants` — creates a variant for an existing product
- **Service method**: `ProductsService.createVariant()` — validates product exists, auto-generates SKU, inserts variant within a transaction
- **Auth**: Requires `MANAGER` role with JWT guard
- **Swagger**: Full API documentation with `@ApiOperation`, `@ApiParam`, `@ApiBody`, `@ApiResponse`

## Related

- Frontend PR: https://github.com/mamuncloud/pns-web/pull/22
- Closes mamuncloud/pns-web#21

## Files Changed

| File | Change |
|------|--------|
| `src/modules/products/products.controller.ts` | Added `POST :id/variants` endpoint |
| `src/modules/products/products.service.ts` | Added `createVariant()` method with SKU generation |

## API Details

```
POST /products/:id/variants
Authorization: Bearer <token>
Role: MANAGER

Body:
{
  "package": "250gr",
  "price": 25000,
  "initialStock": 50,
  "sizeInGram": 250
}

Response:
{
  "message": "Berhasil menambahkan varian baru",
  "data": { "id": "...", "productId": "...", "package": "250gr", ... }
}
```