### PR TITLE
fix(products): resolve 400 bad request error and handle images and taste in update

### DIFF
--- a/src/modules/products/dto/update-product.dto.ts
+++ b/src/modules/products/dto/update-product.dto.ts
@@ -1,0 +1,64 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { 
+  IsArray, 
+  IsBoolean, 
+  IsEnum, 
+  IsNotEmpty, 
+  IsOptional, 
+  IsString, 
+  ValidateNested 
+} from 'class-validator';
+import { ProductTaste } from './create-product.dto';
+
+export class UpdateProductImageDto {
+  @ApiPropertyOptional({ example: 'uuid-123' })
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @ApiPropertyOptional({ example: 'products/sample.png' })
+  @IsString()
+  @IsNotEmpty()
+  url: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsBoolean()
+  isPrimary: boolean;
+}
+
+export class UpdateProductDto {
+  @ApiPropertyOptional({ example: 'Product Name' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'Description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ example: 'brand-uuid' })
+  @IsOptional()
+  @IsString()
+  brandId?: string;
+
+  @ApiPropertyOptional({ enum: ProductTaste, isArray: true, example: [ProductTaste.GURIH] })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(ProductTaste, { each: true })
+  taste?: ProductTaste[];
+
+  @ApiPropertyOptional({ type: [UpdateProductImageDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateProductImageDto)
+  images?: UpdateProductImageDto[];
+
+  @ApiPropertyOptional({ type: [String], example: ['img-uuid-1', 'img-uuid-2'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  removeImageIds?: string[];
+}

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, NotFoundException, Query, Post, Body, Patch, UseGuards } from '@nestjs/common';
-import { ProductsService, UpdateProductDto } from './products.service';
+import { ProductsService } from './products.service';
 import { CreateProductDto, CreateVariantDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
 import { CreateBrandDto } from './dto/create-brand.dto';
 import { ApiOperation, ApiResponse, ApiTags, ApiParam, ApiBearerAuth, ApiQuery, ApiBody } from '@nestjs/swagger';
 import { AllProductsResponseDto, SingleProductResponseDto } from './dto/product-response.dto';

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -7,12 +7,8 @@ import { ConfigService } from '@nestjs/config';
 import { CreateProductDto } from './dto/create-product.dto';
 import { CreateBrandDto } from './dto/create-brand.dto';
 import { generateNextSku } from '../../lib/sku-generator.util';
-
-export class UpdateProductDto {
-  name?: string;
-  description?: string;
-  brandId?: string;
-}
+import { UpdateProductDto } from './dto/update-product.dto';
+import { and, inArray } from 'drizzle-orm';
 
 @Injectable()
 export class ProductsService {
@@ -200,27 +196,71 @@ export class ProductsService {
   }
 
   async update(id: string, dto: UpdateProductDto) {
-    const product = await this.db.query.products.findFirst({
-      where: eq(schema.products.id, id),
+    return await this.db.transaction(async (tx) => {
+      const product = await tx.query.products.findFirst({
+        where: eq(schema.products.id, id),
+      });
+
+      if (!product) {
+        throw new NotFoundException(`Produk dengan ID ${id} tidak ditemukan`);
+      }
+
+      // 1. Update basic product info
+      const updateValues: Partial<typeof schema.products.$inferInsert> = {};
+      if (dto.name !== undefined) updateValues.name = dto.name;
+      if (dto.description !== undefined) updateValues.description = dto.description;
+      if (dto.brandId !== undefined) updateValues.brandId = dto.brandId;
+      if (dto.taste !== undefined) updateValues.taste = dto.taste;
+
+      if (Object.keys(updateValues).length > 0) {
+        await tx
+          .update(schema.products)
+          .set(updateValues)
+          .where(eq(schema.products.id, id));
+      }
+
+      // 2. Remove images if requested
+      if (dto.removeImageIds && dto.removeImageIds.length > 0) {
+        await tx
+          .delete(schema.productImages)
+          .where(
+            and(
+              eq(schema.productImages.productId, id),
+              inArray(schema.productImages.id, dto.removeImageIds)
+            )
+          );
+      }
+
+      // 3. Handle image updates/additions
+      if (dto.images && dto.images.length > 0) {
+        for (const imgDto of dto.images) {
+          if (imgDto.id) {
+            // Update existing image
+            await tx
+              .update(schema.productImages)
+              .set({
+                url: imgDto.url,
+                isPrimary: imgDto.isPrimary,
+              })
+              .where(
+                and(
+                  eq(schema.productImages.id, imgDto.id),
+                  eq(schema.productImages.productId, id)
+                )
+              );
+          } else {
+            // Add new image
+            await tx.insert(schema.productImages).values({
+              productId: id,
+              url: imgDto.url,
+              isPrimary: imgDto.isPrimary,
+            });
+          }
+        }
+      }
+
+      return this.findOne(id);
     });
-
-    if (!product) {
-      throw new NotFoundException(`Produk dengan ID ${id} tidak ditemukan`);
-    }
-
-    const updateValues: Partial<typeof schema.products.$inferInsert> = {};
-    if (dto.name !== undefined) updateValues.name = dto.name;
-    if (dto.description !== undefined) updateValues.description = dto.description;
-    if (dto.brandId !== undefined) updateValues.brandId = dto.brandId;
-
-    if (Object.keys(updateValues).length > 0) {
-      await this.db
-        .update(schema.products)
-        .set(updateValues)
-        .where(eq(schema.products.id, id));
-    }
-
-    return this.findOne(id);
   }
 
   async findBrands(search?: string) {


### PR DESCRIPTION
## Summary
The endpoint `PATCH /products/:id` was returning a `400 Bad Request` error when updating products because the `UpdateProductDto` was missing several fields sent by the frontend (`taste`, `images`, `removeImageIds`) and lacked proper validation decorators.

## Changes
- Created a robust `UpdateProductDto` in `src/modules/products/dto/update-product.dto.ts`.
- Updated `ProductsService.update` to handle `taste`, `images`, and `removeImageIds` within a transaction.
- Updated `ProductsController` to use the new DTO and expanded API documentation.

## Fixes
Closes #12