### PR TITLE
feat(auth): send magic link via WhatsApp alongside email (Vibe Kanban)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ RESEND_API_KEY="re_xxxxxxxxxxxxxxxx"
 MAIL_FROM="onboarding@resend.dev"
 JWT_SECRET="secret"
 JWT_EXPIRES_IN="5m"
+
+# WhatsApp API Configuration
+WHATSAPP_BASE_URL="https://whatsapp.planetnyemilsnack.store"
+WHATSAPP_DEVICE_ID="your-device-uuid"
+WHATSAPP_USERNAME="planet"
+WHATSAPP_PASSWORD="nyemilsnack"

--- a/drizzle/20260402-0000-add_phone_to_employees.sql
+++ b/drizzle/20260402-0000-add_phone_to_employees.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "employees" ADD COLUMN "phone" varchar(255) UNIQUE;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -64,6 +64,7 @@ export const users = pgTable("users", {
 export const employees = pgTable("employees", {
   id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
   email: varchar("email", { length: 255 }).unique().notNull(),
+  phone: varchar("phone", { length: 255 }).unique(),
   name: varchar("name", { length: 255 }).notNull(),
   role: employeeRoleEnum("role").notNull().default("CASHIER"),
   createdAt: timestamp("createdAt").defaultNow().notNull(),

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -7,12 +7,14 @@ import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { DatabaseModule } from 'src/common/database/database.module';
 import { MailsModule } from '../mails/mails.module';
+import { WhatsappModule } from '../whatsapp/whatsapp.module';
 
 @Module({
   imports: [
     DatabaseModule,
     PassportModule,
     MailsModule,
+    WhatsappModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException, Logger, Inject } from '@nestjs/commo
 import { JwtService } from '@nestjs/jwt';
 import { DRIZZLE_DB } from '../../common/database/database.module';
 import { MailsService } from '../mails/mails.service';
+import { WhatsappService } from '../whatsapp/whatsapp.service';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../../db/schema';
 import { eq, and, gt } from 'drizzle-orm';
@@ -16,6 +17,7 @@ export class AuthService {
     @Inject(DRIZZLE_DB)
     private readonly db: NodePgDatabase<typeof schema>,
     private readonly mailsService: MailsService,
+    private readonly whatsappService: WhatsappService,
   ) {}
 
   async requestLogin(email: string) {
@@ -32,7 +34,7 @@ export class AuthService {
     if (!employee && !user) {
       // For security reasons, don't reveal if the email exists
       this.logger.warn(`Login attempt for non-existent email: ${email}`);
-      return { message: 'If you are registered, a login link will be sent to your email.' };
+      return { message: 'If you are registered, a login link will be sent to your email and WhatsApp.' };
     }
 
     // 3. Generate token
@@ -54,8 +56,18 @@ export class AuthService {
     
     const userName = employee?.name || user?.name || 'User';
     await this.mailsService.sendMagicLink(email, magicLink, userName);
+
+    // 6. Send WhatsApp message if phone is available
+    const phone = employee?.phone || user?.phone;
+    if (phone) {
+      const waMessage = `*Planet Nyemil Snack* 🍪\nWelcome back, *${userName}*! 👋\n\nClick the link below to log in to your account. This link will expire in *15 minutes*. ⏳\n\n🔗 ${magicLink}\n\n_If you did not request this link, please ignore this message._`;
+      // Fire and forget - don't block the response
+      this.whatsappService.sendMessage(phone, waMessage).catch((err) => {
+        this.logger.error(`Failed to send WhatsApp message for ${email}: ${err.message}`);
+      });
+    }
     
-    return { message: 'If you are registered, a login link will be sent to your email.' };
+    return { message: 'If you are registered, a login link will be sent to your email and WhatsApp.' };
   }
 
   async verifyLogin(token: string) {

--- a/src/modules/whatsapp/whatsapp.module.ts
+++ b/src/modules/whatsapp/whatsapp.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { WhatsappService } from './whatsapp.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [WhatsappService],
+  exports: [WhatsappService],
+})
+export class WhatsappModule {}

--- a/src/modules/whatsapp/whatsapp.service.ts
+++ b/src/modules/whatsapp/whatsapp.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class WhatsappService {
+  private readonly logger = new Logger(WhatsappService.name);
+  private readonly baseUrl: string;
+  private readonly deviceId: string;
+  private readonly username: string;
+  private readonly password: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.baseUrl = this.configService.get<string>('WHATSAPP_BASE_URL') || '';
+    this.deviceId = this.configService.get<string>('WHATSAPP_DEVICE_ID') || '';
+    this.username = this.configService.get<string>('WHATSAPP_USERNAME') || '';
+    this.password = this.configService.get<string>('WHATSAPP_PASSWORD') || '';
+
+    if (!this.baseUrl || !this.deviceId) {
+      this.logger.warn('WhatsApp configuration is incomplete. WhatsApp messages will not be sent.');
+    }
+  }
+
+  async sendMessage(phone: string, message: string): Promise<void> {
+    if (!this.baseUrl || !this.deviceId) {
+      this.logger.warn('WhatsApp not configured. Skipping message.');
+      return;
+    }
+
+    const jid = phone.includes('@s.whatsapp.net') ? phone : `${phone}@s.whatsapp.net`;
+
+    try {
+      this.logger.log(`Sending WhatsApp message to ${phone}`);
+
+      const response = await fetch(`${this.baseUrl}/send/message`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Device-Id': this.deviceId,
+          'Authorization': `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`,
+        },
+        body: JSON.stringify({
+          phone: jid,
+          message,
+          is_forwarded: false,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        this.logger.error(`Failed to send WhatsApp message to ${phone}: ${JSON.stringify(data)}`);
+        return;
+      }
+
+      this.logger.log(`WhatsApp message sent successfully to ${phone}`);
+    } catch (err) {
+      this.logger.error(`Unexpected error sending WhatsApp message to ${phone}: ${err.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Added WhatsApp delivery for magic link login, sending the link via both email and WhatsApp for redundancy
- Added `phone` column to the `employees` table to support WhatsApp delivery for staff accounts
- Created a new `WhatsappModule` that integrates with the external WhatsApp API (`whatsapp.planetnyemilsnack.store`)

## Changes

### Backend (`pns-server`)

| File | Change |
|------|--------|
| `src/db/schema.ts` | Added `phone` column to `employees` table (nullable, unique) |
| `src/modules/whatsapp/whatsapp.service.ts` | **New** — WhatsApp messaging service using the external API with Basic Auth and `X-Device-Id` header. Auto-formats phone numbers to WhatsApp JID format (`+62xxx@s.whatsapp.net`) |
| `src/modules/whatsapp/whatsapp.module.ts` | **New** — NestJS module wrapping the WhatsApp service |
| `src/modules/auth/auth.module.ts` | Imported `WhatsappModule` into the auth module |
| `src/modules/auth/auth.service.ts` | After sending the magic link email, fire-and-forgets a WhatsApp message if the user/employee has a phone number. Updated generic response messages to mention both email and WhatsApp |
| `.env.example` | Added `WHATSAPP_BASE_URL`, `WHATSAPP_DEVICE_ID`, `WHATSAPP_USERNAME`, `WHATSAPP_PASSWORD` |
| `drizzle/20260402-0000-add_phone_to_employees.sql` | **New** — Migration to add the phone column |

## Implementation Details

- **Dual delivery**: Email is always sent first (awaited). WhatsApp is sent fire-and-forget so it doesn't block the API response — if WhatsApp fails, the user still gets the link via email.
- **Graceful degradation**: If WhatsApp env vars are not configured, the service logs a warning and silently skips WhatsApp delivery. The login flow works fully with email alone.
- **Phone number handling**: The `phone` field is nullable on employees, so existing records are unaffected. WhatsApp messages are only sent when a phone number is present. Phone numbers are auto-formatted to WhatsApp JID format if needed.
- **Security**: The same generic message is returned regardless of whether the email exists, whether a phone number is configured, or whether WhatsApp delivery succeeds — preventing information leakage.

## Before Deploying

1. Run the migration: `bun run db:migrate`
2. Set the 4 new WhatsApp env vars in your production `.env`
3. Add phone numbers to existing employees via admin panel or database

This PR was written using [Vibe Kanban](https://vibekanban.com)