### PR TITLE
feat: add finance and expense tracking modules

### DIFF
--- a/list-categories.ts
+++ b/list-categories.ts
@@ -1,0 +1,21 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from './src/db/schema';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const db = drizzle(pool, { schema });
+
+async function listCategories() {
+  const categories = await db.query.expenseCategories.findMany();
+  console.log('--- EXPENSE CATEGORIES ---');
+  console.log(JSON.stringify(categories, null, 2));
+  await pool.end();
+}
+
+listCategories();

--- a/scripts/check-db.ts
+++ b/scripts/check-db.ts
@@ -1,0 +1,19 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from '../src/db/schema';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+const db = drizzle(pool, { schema });
+
+async function checkEmployees() {
+  const allEmployees = await db.query.employees.findMany();
+  console.log('Employees in DB:', JSON.stringify(allEmployees, null, 2));
+  process.exit(0);
+}
+
+checkEmployees();

--- a/scripts/test-login.ts
+++ b/scripts/test-login.ts
@@ -1,0 +1,39 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from '../src/db/schema';
+import { eq } from 'drizzle-orm';
+import * as dotenv from 'dotenv';
+import * as crypto from 'crypto';
+
+dotenv.config();
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+const db = drizzle(pool, { schema });
+
+async function createTestToken() {
+  const manager = await db.query.employees.findFirst({
+    where: eq(schema.employees.email, 'planetnyemilsnack@gmail.com'),
+  });
+
+  if (!manager) {
+    console.error('❌ Manager not found!');
+    process.exit(1);
+  }
+
+  const token = 'test-token-' + crypto.randomBytes(8).toString('hex');
+  const expiresAt = new Date();
+  expiresAt.setHours(expiresAt.getHours() + 1);
+
+  await db.insert(schema.authTokens).values({
+    employeeId: manager.id,
+    token: token,
+    expiresAt: expiresAt,
+  });
+
+  console.log(`✅ Login URL: http://localhost:3000/staff/verify?token=${token}`);
+  process.exit(0);
+}
+
+createTestToken();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,8 @@ import { StoreSettingsModule } from 'src/modules/store-settings/store-settings.m
 import { RepacksModule } from 'src/modules/repacks/repacks.module';
 import { StockModule } from 'src/modules/stock/stock.module';
 import { EmployeesModule } from 'src/modules/employees/employees.module';
+import { FinanceModule } from 'src/modules/finance/finance.module';
+import { ExpensesModule } from 'src/modules/expenses/expenses.module';
 
 @Module({
   imports: [
@@ -34,6 +36,8 @@ import { EmployeesModule } from 'src/modules/employees/employees.module';
     StoreSettingsModule,
     RepacksModule,
     EmployeesModule,
+    FinanceModule,
+    ExpensesModule,
   ],
 })
 export class AppModule {}

--- a/src/db/check-db.ts
+++ b/src/db/check-db.ts
@@ -1,0 +1,40 @@
+import { Client } from 'pg';
+import * as dotenv from 'dotenv';
+import { resolve } from 'path';
+
+dotenv.config({ path: resolve(__dirname, '../.env') });
+
+async function checkDb() {
+  const client = new Client({
+    connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+  });
+  
+  try {
+    await client.connect();
+    console.log('Connected to Database');
+    
+    // Check for existing enums
+    const enumsRes = await client.query(`
+      SELECT n.nspname as schema, t.typname as name
+      FROM pg_type t
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE (t.typtype = 'e')
+    `);
+    console.log('Existing Enums:', enumsRes.rows.map(r => r.name));
+    
+    // Check for existing tables
+    const tablesRes = await client.query(`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = 'public'
+    `);
+    console.log('Existing Tables:', tablesRes.rows.map(r => r.table_name));
+    
+  } catch (err) {
+    console.error('Error:', err);
+  } finally {
+    await client.end();
+  }
+}
+
+checkDb();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -42,6 +42,16 @@ export const stockMovementTypeEnum = pgEnum("StockMovementType", [
 
 export const paymentMethodEnum = pgEnum("PaymentMethod", ["CASH", "QRIS"]);
 
+export const transactionTypeEnum = pgEnum("TransactionType", ["INCOME", "EXPENSE"]);
+
+export const transactionCategoryEnum = pgEnum("TransactionCategory", [
+  "SALES",
+  "STOCK_PURCHASE",
+  "OPERATIONAL_EXPENSE",
+  "CAPITAL_INJECTION",
+  "ADJUSTMENT",
+]);
+
 // Tables
 export const users = pgTable("users", {
   id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
@@ -325,6 +335,8 @@ export const usersRelations = relations(users, ({ many }) => ({
 export const employeesRelations = relations(employees, ({ many }) => ({
   authTokens: many(authTokens),
   refreshTokens: many(refreshTokens),
+  expenses: many(expenses),
+  financialTransactions: many(financialTransactions),
 }));
 
 export const refreshTokensRelations = relations(refreshTokens, ({ one }) => ({
@@ -474,3 +486,70 @@ export const stockMovementsRelations = relations(stockMovements, ({ one }) => ({
   }),
 }));
 
+
+export const expenseCategories = pgTable("expense_categories", {
+  id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  name: varchar("name", { length: 255 }).notNull(),
+  description: text("description"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt")
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+});
+
+export const expenses = pgTable("expenses", {
+  id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  categoryId: varchar("categoryId", { length: 255 })
+    .references(() => expenseCategories.id)
+    .notNull(),
+  amount: integer("amount").notNull(),
+  date: timestamp("date").defaultNow().notNull(),
+  description: text("description"),
+  receiptUrl: text("receiptUrl"),
+  employeeId: varchar("employeeId", { length: 255 }).references(() => employees.id),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt")
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+});
+
+export const financialTransactions = pgTable("financial_transactions", {
+  id: varchar("id", { length: 255 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+  type: transactionTypeEnum("type").notNull(),
+  category: transactionCategoryEnum("category").notNull(),
+  amount: integer("amount").notNull(),
+  date: timestamp("date").defaultNow().notNull(),
+  description: text("description"),
+  paymentMethod: paymentMethodEnum("paymentMethod").default("CASH").notNull(),
+  referenceId: varchar("referenceId", { length: 255 }), // Can be Order ID, Purchase ID, or Expense ID
+  employeeId: varchar("employeeId", { length: 255 }).references(() => employees.id),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt")
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+});
+
+export const expenseCategoriesRelations = relations(expenseCategories, ({ many }) => ({
+  expenses: many(expenses),
+}));
+
+export const expensesRelations = relations(expenses, ({ one }) => ({
+  category: one(expenseCategories, {
+    fields: [expenses.categoryId],
+    references: [expenseCategories.id],
+  }),
+  employee: one(employees, {
+    fields: [expenses.employeeId],
+    references: [employees.id],
+  }),
+}));
+
+export const financialTransactionsRelations = relations(financialTransactions, ({ one }) => ({
+  employee: one(employees, {
+    fields: [financialTransactions.employeeId],
+    references: [employees.id],
+  }),
+}));

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -13,13 +13,24 @@ async function seed() {
   console.log('🌱 Seeding database...');
 
   try {
-    // Clear existing data in correct order
-    console.log('🧹 Cleaning existing data...');
-    await db.delete(schema.orderItems);
+    await db.delete(schema.orderItems); 
+    await db.delete(schema.repacks);
+    await db.delete(schema.purchaseItems);
+    await db.delete(schema.stockMovements);
+    await db.delete(schema.expenses);
+    await db.delete(schema.financialTransactions);
+    await db.delete(schema.pricingRules);
+    await db.delete(schema.orders);
+    await db.delete(schema.purchases);
     await db.delete(schema.productVariants);
     await db.delete(schema.products);
+    await db.delete(schema.expenseCategories);
+    await db.delete(schema.users);
+    await db.delete(schema.brands);
+    await db.delete(schema.suppliers);
+    await db.delete(schema.storeSettings);
 
-    const tastes = ['Pedas', 'Gurih', 'Manis'];
+    const tastes = ['PEDAS', 'GURIH', 'MANIS'];
     const labels = ['Medium', 'Small', '250gr', '500gr', '1kg', 'bal'];
     const snackNames = [
       'Keripik Kaca', 'Makaroni Ngocor', 'Basreng Gila', 'Usus Pedas', 'Cireng Krispi',
@@ -77,6 +88,23 @@ async function seed() {
 
     await db.insert(schema.productVariants).values(variantsToInsert);
     console.log(`✅ Inserted ${variantsToInsert.length} product variants.`);
+
+    console.log('💰 Seeding expense categories...');
+    const expenseCategories = [
+      { name: 'Listrik & Air', description: 'Biaya utilitas bulanan' },
+      { name: 'Sewa Bangunan', description: 'Biaya sewa toko' },
+      { name: 'Gaji Karyawan', description: 'Pembayaran upah staf' },
+      { name: 'Perlengkapan Toko', description: 'ATK, pembersih, dll' },
+      { name: 'Logistik', description: 'Biaya pengiriman dan transportasi' },
+      { name: 'Pemasaran', description: 'Iklan dan promosi' },
+      { name: 'Lain-lain', description: 'Biaya tidak terduga lainnya' },
+    ];
+
+    await db.insert(schema.expenseCategories).values(expenseCategories.map(cat => ({
+      id: crypto.randomUUID(),
+      ...cat
+    })));
+    console.log(`✅ Inserted ${expenseCategories.length} expense categories.`);
 
     console.log('✨ Seeding completed successfully!');
   } catch (error) {

--- a/src/modules/expenses/dto/create-expense-category.dto.ts
+++ b/src/modules/expenses/dto/create-expense-category.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class CreateExpenseCategoryDto {
+  @ApiProperty({ example: 'Listrik & Air' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: 'Biaya utilitas bulanan', required: false })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/src/modules/expenses/dto/create-expense.dto.ts
+++ b/src/modules/expenses/dto/create-expense.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsInt, IsOptional, IsDateString } from 'class-validator';
+
+export class CreateExpenseDto {
+  @ApiProperty({ example: 'expense-cat-1' })
+  @IsString()
+  @IsNotEmpty()
+  categoryId: string;
+
+  @ApiProperty({ example: 500000 })
+  @IsInt()
+  @IsNotEmpty()
+  amount: number;
+
+  @ApiProperty({ example: 'Bayar listrik bulan April' })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({ example: '2026-04-03T00:00:00Z', required: false })
+  @IsDateString()
+  @IsOptional()
+  date?: string;
+
+  @ApiProperty({ example: 'https://storage.example.com/receipt.jpg', required: false })
+  @IsString()
+  @IsOptional()
+  receiptUrl?: string;
+
+  @ApiProperty({ example: 'emp-1', required: false })
+  @IsString()
+  @IsOptional()
+  employeeId?: string;
+}

--- a/src/modules/expenses/dto/update-expense-category.dto.ts
+++ b/src/modules/expenses/dto/update-expense-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateExpenseCategoryDto } from './create-expense-category.dto';
+
+export class UpdateExpenseCategoryDto extends PartialType(CreateExpenseCategoryDto) {}

--- a/src/modules/expenses/dto/update-expense.dto.ts
+++ b/src/modules/expenses/dto/update-expense.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateExpenseDto } from './create-expense.dto';
+
+export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}

--- a/src/modules/expenses/expenses.controller.ts
+++ b/src/modules/expenses/expenses.controller.ts
@@ -1,0 +1,99 @@
+import { Controller, Get, Post, Patch, Delete, Body, Query, Param, UseGuards } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+
+@ApiTags('Expenses')
+@Controller('expenses')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ExpensesController {
+  constructor(private readonly expensesService: ExpensesService) {}
+
+  @Get('categories')
+  @ApiOperation({ summary: 'List all expense categories' })
+  @ApiResponse({ status: 200, description: 'Return categories' })
+  async getCategories() {
+    return await this.expensesService.findAllCategories();
+  }
+
+  @Get('categories/:id')
+  @ApiOperation({ summary: 'Get a specific expense category' })
+  @ApiParam({ name: 'id', description: 'Category ID' })
+  @ApiResponse({ status: 200, description: 'Return category' })
+  async getCategory(@Param('id') id: string) {
+    return await this.expensesService.findOneCategory(id);
+  }
+
+  @Post('categories')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Create a new expense category' })
+  @ApiResponse({ status: 201, description: 'Category created' })
+  async createCategory(@Body() dto: CreateExpenseCategoryDto) {
+    return await this.expensesService.createCategory(dto);
+  }
+
+  @Patch('categories/:id')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Update an expense category' })
+  @ApiParam({ name: 'id', description: 'Category ID' })
+  @ApiResponse({ status: 200, description: 'Category updated' })
+  async updateCategory(@Param('id') id: string, @Body() dto: UpdateExpenseCategoryDto) {
+    return await this.expensesService.updateCategory(id, dto);
+  }
+
+  @Delete('categories/:id')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Delete an expense category' })
+  @ApiParam({ name: 'id', description: 'Category ID' })
+  @ApiResponse({ status: 200, description: 'Category deleted' })
+  async removeCategory(@Param('id') id: string) {
+    return await this.expensesService.removeCategory(id);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all expenses with filters' })
+  @ApiResponse({ status: 200, description: 'Return expenses' })
+  async getExpenses(@Query('categoryId') categoryId?: string) {
+    return await this.expensesService.findAll({ categoryId });
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a specific expense record' })
+  @ApiParam({ name: 'id', description: 'Expense ID' })
+  @ApiResponse({ status: 200, description: 'Return expense' })
+  async getExpense(@Param('id') id: string) {
+    return await this.expensesService.findOne(id);
+  }
+
+  @Post()
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Record a new expense' })
+  @ApiResponse({ status: 201, description: 'Expense recorded' })
+  async createExpense(@Body() dto: CreateExpenseDto) {
+    return await this.expensesService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Update an existing expense' })
+  @ApiParam({ name: 'id', description: 'Expense ID' })
+  @ApiResponse({ status: 200, description: 'Expense updated' })
+  async updateExpense(@Param('id') id: string, @Body() dto: UpdateExpenseDto) {
+    return await this.expensesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Delete an expense record' })
+  @ApiParam({ name: 'id', description: 'Expense ID' })
+  @ApiResponse({ status: 200, description: 'Expense deleted' })
+  async removeExpense(@Param('id') id: string) {
+    return await this.expensesService.remove(id);
+  }
+}

--- a/src/modules/expenses/expenses.module.ts
+++ b/src/modules/expenses/expenses.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { ExpensesController } from './expenses.controller';
+
+@Module({
+  controllers: [ExpensesController],
+  providers: [ExpensesService],
+  exports: [ExpensesService],
+})
+export class ExpensesModule {}

--- a/src/modules/expenses/expenses.service.ts
+++ b/src/modules/expenses/expenses.service.ts
@@ -1,0 +1,217 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { DRIZZLE_DB } from '../../common/database/database.module';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '../../db/schema';
+import { eq, desc } from 'drizzle-orm';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+import { FinanceService } from '../finance/finance.service';
+
+@Injectable()
+export class ExpensesService {
+  constructor(
+    @Inject(DRIZZLE_DB)
+    private readonly db: NodePgDatabase<typeof schema>,
+    private readonly financeService: FinanceService,
+  ) {}
+
+  /**
+   * Kategori Biaya
+   */
+  async createCategory(dto: CreateExpenseCategoryDto) {
+    const [category] = await this.db.insert(schema.expenseCategories).values({
+      name: dto.name,
+      description: dto.description,
+    }).returning();
+    return category;
+  }
+
+  async findAllCategories() {
+    return await this.db.query.expenseCategories.findMany({
+      orderBy: [desc(schema.expenseCategories.createdAt)],
+    });
+  }
+
+  async findOneCategory(id: string) {
+    const category = await this.db.query.expenseCategories.findFirst({
+      where: eq(schema.expenseCategories.id, id),
+    });
+    if (!category) {
+      throw new NotFoundException(`Kategori biaya dengan ID ${id} tidak ditemukan`);
+    }
+    return category;
+  }
+
+  async updateCategory(id: string, dto: UpdateExpenseCategoryDto) {
+    const [category] = await this.db
+      .update(schema.expenseCategories)
+      .set({
+        ...dto,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.expenseCategories.id, id))
+      .returning();
+
+    if (!category) {
+      throw new NotFoundException(`Kategori biaya dengan ID ${id} tidak ditemukan`);
+    }
+    return category;
+  }
+
+  async removeCategory(id: string) {
+    // Check if there are expenses using this category
+    const expenseCount = await this.db.query.expenses.findFirst({
+      where: eq(schema.expenses.categoryId, id),
+    });
+
+    if (expenseCount) {
+      throw new Error('Kategori tidak dapat dihapus karena masih digunakan oleh data biaya');
+    }
+
+    const [category] = await this.db
+      .delete(schema.expenseCategories)
+      .where(eq(schema.expenseCategories.id, id))
+      .returning();
+
+    if (!category) {
+      throw new NotFoundException(`Kategori biaya dengan ID ${id} tidak ditemukan`);
+    }
+    return category;
+  }
+
+  /**
+   * Biaya (Expenses)
+   */
+  async create(dto: CreateExpenseDto) {
+    return await this.db.transaction(async (tx) => {
+      // 1. Verify category
+      const category = await tx.query.expenseCategories.findFirst({
+        where: eq(schema.expenseCategories.id, dto.categoryId),
+      });
+
+      if (!category) {
+        throw new NotFoundException(`Kategori biaya dengan ID ${dto.categoryId} tidak ditemukan`);
+      }
+
+      // 2. Create expense record
+      const [expense] = await tx.insert(schema.expenses).values({
+        categoryId: dto.categoryId,
+        amount: dto.amount,
+        description: dto.description,
+        receiptUrl: dto.receiptUrl,
+        employeeId: dto.employeeId,
+        date: dto.date ? new Date(dto.date) : new Date(),
+      }).returning();
+
+      // 3. Record in financial ledger
+      await this.financeService.recordTransaction({
+        type: 'EXPENSE',
+        category: 'OPERATIONAL_EXPENSE',
+        amount: dto.amount,
+        description: `${category.name} | ${dto.description || ''}`,
+        paymentMethod: 'CASH',
+        referenceId: expense.id,
+        employeeId: dto.employeeId,
+        date: expense.date,
+      }, tx);
+
+      return expense;
+    });
+  }
+
+  async findAll(params?: { categoryId?: string }) {
+    return await this.db.query.expenses.findMany({
+      where: params?.categoryId ? eq(schema.expenses.categoryId, params.categoryId) : undefined,
+      with: {
+        category: true,
+        employee: {
+          columns: { name: true }
+        }
+      },
+      orderBy: [desc(schema.expenses.date)],
+    });
+  }
+
+  async findOne(id: string) {
+    const expense = await this.db.query.expenses.findFirst({
+      where: eq(schema.expenses.id, id),
+      with: {
+        category: true,
+        employee: {
+          columns: { name: true }
+        }
+      },
+    });
+    if (!expense) {
+      throw new NotFoundException(`Biaya dengan ID ${id} tidak ditemukan`);
+    }
+    return expense;
+  }
+
+  async update(id: string, dto: UpdateExpenseDto) {
+    return await this.db.transaction(async (tx) => {
+      // 1. Get current expense
+      const oldExpense = await tx.query.expenses.findFirst({
+        where: eq(schema.expenses.id, id),
+      });
+
+      if (!oldExpense) {
+        throw new NotFoundException(`Biaya dengan ID ${id} tidak ditemukan`);
+      }
+
+      // 2. Update expense record
+      const [expense] = await tx
+        .update(schema.expenses)
+        .set({
+          categoryId: dto.categoryId,
+          amount: dto.amount,
+          description: dto.description,
+          receiptUrl: dto.receiptUrl,
+          employeeId: dto.employeeId,
+          date: dto.date ? new Date(dto.date) : undefined,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.expenses.id, id))
+        .returning();
+
+      // 3. Sync with ledger
+      const category = await tx.query.expenseCategories.findFirst({
+        where: eq(schema.expenseCategories.id, expense.categoryId),
+      });
+
+      await this.financeService.updateTransactionByReference(
+        expense.id,
+        {
+          amount: expense.amount,
+          description: `${category?.name || 'Lain-lain'} | ${expense.description || ''}`,
+          date: expense.date,
+          employeeId: expense.employeeId,
+        },
+        tx,
+      );
+
+      return expense;
+    });
+  }
+
+  async remove(id: string) {
+    return await this.db.transaction(async (tx) => {
+      // 1. Delete expense
+      const [expense] = await tx
+        .delete(schema.expenses)
+        .where(eq(schema.expenses.id, id))
+        .returning();
+
+      if (!expense) {
+        throw new NotFoundException(`Biaya dengan ID ${id} tidak ditemukan`);
+      }
+
+      // 2. Remove ledger entry
+      await this.financeService.deleteTransactionByReference(id, tx);
+
+      return expense;
+    });
+  }
+}

--- a/src/modules/finance/dto/record-adjustment.dto.ts
+++ b/src/modules/finance/dto/record-adjustment.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class RecordAdjustmentDto {
+  @ApiProperty({ enum: ['INCOME', 'EXPENSE'] })
+  @IsEnum(['INCOME', 'EXPENSE'])
+  type: 'INCOME' | 'EXPENSE';
+
+  @ApiProperty({ enum: ['CAPITAL_INJECTION', 'ADJUSTMENT'] })
+  @IsEnum(['CAPITAL_INJECTION', 'ADJUSTMENT'])
+  category: 'CAPITAL_INJECTION' | 'ADJUSTMENT';
+
+  @ApiProperty({ example: 1000000 })
+  @IsInt()
+  @IsNotEmpty()
+  amount: number;
+
+  @ApiProperty({ example: 'Modal awal toko' })
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @ApiProperty({ enum: ['CASH', 'QRIS'], required: false, default: 'CASH' })
+  @IsEnum(['CASH', 'QRIS'])
+  @IsOptional()
+  paymentMethod?: 'CASH' | 'QRIS';
+}

--- a/src/modules/finance/finance.controller.ts
+++ b/src/modules/finance/finance.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Post, Body, Query, UseGuards } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RecordAdjustmentDto } from './dto/record-adjustment.dto';
+
+@ApiTags('Finance')
+@Controller('finance')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FinanceController {
+  constructor(private readonly financeService: FinanceService) {}
+
+  @Get('summary')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Get financial summary (P&L)' })
+  @ApiResponse({ status: 200, description: 'Return financial summary' })
+  async getSummary() {
+    return await this.financeService.getSummary();
+  }
+
+  @Get('ledger')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Get detailed financial ledger' })
+  @ApiResponse({ status: 200, description: 'Return ledger entries' })
+  async getLedger(
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('category') category?: string,
+    @Query('type') type?: string,
+  ) {
+    return await this.financeService.getLedger({ startDate, endDate, category, type });
+  }
+
+  @Post('adjustment')
+  @Roles('MANAGER')
+  @ApiOperation({ summary: 'Record a financial adjustment (e.g. Initial Capital)' })
+  @ApiResponse({ status: 201, description: 'Adjustment recorded' })
+  async recordAdjustment(
+    @Body() dto: RecordAdjustmentDto
+  ) {
+    return await this.financeService.recordTransaction({
+      ...dto,
+      date: new Date(),
+    });
+  }
+}

--- a/src/modules/finance/finance.module.ts
+++ b/src/modules/finance/finance.module.ts
@@ -1,0 +1,11 @@
+import { Module, Global } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { FinanceController } from './finance.controller';
+
+@Global()
+@Module({
+  controllers: [FinanceController],
+  providers: [FinanceService],
+  exports: [FinanceService],
+})
+export class FinanceModule {}

--- a/src/modules/finance/finance.service.ts
+++ b/src/modules/finance/finance.service.ts
@@ -1,0 +1,179 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE_DB } from '../../common/database/database.module';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '../../db/schema';
+import { eq, desc, sql, sum, and, gte, lte } from 'drizzle-orm';
+
+export interface RecordTransactionPayload {
+  type: (typeof schema.transactionTypeEnum.enumValues)[number];
+  category: (typeof schema.transactionCategoryEnum.enumValues)[number];
+  amount: number;
+  description?: string;
+  paymentMethod?: (typeof schema.paymentMethodEnum.enumValues)[number];
+  referenceId?: string;
+  employeeId?: string;
+  date?: Date;
+}
+
+@Injectable()
+export class FinanceService {
+  constructor(
+    @Inject(DRIZZLE_DB)
+    private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Records a financial transaction. Can be used within an existing database transaction.
+   */
+  async recordTransaction(payload: RecordTransactionPayload, tx?: NodePgDatabase<typeof schema>) {
+    const db = tx || this.db;
+
+    return await db
+      .insert(schema.financialTransactions)
+      .values({
+        type: payload.type,
+        category: payload.category,
+        amount: payload.amount,
+        description: payload.description,
+        paymentMethod: payload.paymentMethod || 'CASH',
+        referenceId: payload.referenceId,
+        employeeId: payload.employeeId,
+        date: payload.date || new Date(),
+      })
+      .returning();
+  }
+
+  /**
+   * Updates a transaction found by its referenceId (e.g. Expense ID)
+   */
+  async updateTransactionByReference(
+    referenceId: string,
+    payload: Partial<RecordTransactionPayload>,
+    tx?: NodePgDatabase<typeof schema>,
+  ) {
+    const db = tx || this.db;
+    return await db
+      .update(schema.financialTransactions)
+      .set({
+        amount: payload.amount,
+        description: payload.description,
+        type: payload.type,
+        category: payload.category,
+        paymentMethod: payload.paymentMethod,
+        date: payload.date,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.financialTransactions.referenceId, referenceId))
+      .returning();
+  }
+
+  /**
+   * Deletes a transaction found by its referenceId
+   */
+  async deleteTransactionByReference(referenceId: string, tx?: NodePgDatabase<typeof schema>) {
+    const db = tx || this.db;
+    return await db
+      .delete(schema.financialTransactions)
+      .where(eq(schema.financialTransactions.referenceId, referenceId))
+      .returning();
+  }
+
+  /**
+   * Get ledger entries with filters
+   */
+  async getLedger(params?: { startDate?: string; endDate?: string; category?: any; type?: any }) {
+    const conditions = [];
+
+    if (params?.startDate) {
+      conditions.push(gte(schema.financialTransactions.date, new Date(params.startDate)));
+    }
+    if (params?.endDate) {
+      conditions.push(lte(schema.financialTransactions.date, new Date(params.endDate)));
+    }
+    if (params?.type) {
+      conditions.push(eq(schema.financialTransactions.type, params.type));
+    }
+    if (params?.category) {
+      conditions.push(eq(schema.financialTransactions.category, params.category));
+    }
+
+    return await this.db.query.financialTransactions.findMany({
+      where: conditions.length > 0 ? and(...conditions) : undefined,
+      orderBy: [desc(schema.financialTransactions.date)],
+      with: {
+        employee: {
+          columns: { name: true },
+        },
+      },
+    });
+  }
+
+  /**
+   * Get financial summary (P&L) with deep business insights
+   */
+  async getSummary() {
+    // 1. Get total per type (Income vs Expense)
+    const typeSummary = await this.db
+      .select({
+        type: schema.financialTransactions.type,
+        total: sum(schema.financialTransactions.amount),
+      })
+      .from(schema.financialTransactions)
+      .groupBy(schema.financialTransactions.type);
+
+    const _totalIncome = Number(typeSummary.find((r) => r.type === 'INCOME')?.total || 0);
+    const _totalExpense = Number(typeSummary.find((r) => r.type === 'EXPENSE')?.total || 0);
+
+    // 2. Get specific breakdowns
+    const categoryBreakdown = await this.db
+      .select({
+        category: schema.financialTransactions.category,
+        total: sum(schema.financialTransactions.amount),
+      })
+      .from(schema.financialTransactions)
+      .groupBy(schema.financialTransactions.category);
+
+    const revenue = Number(categoryBreakdown.find((r) => r.category === 'SALES')?.total || 0);
+    const cogs = Number(categoryBreakdown.find((r) => r.category === 'STOCK_PURCHASE')?.total || 0);
+    const expenses = Number(
+      categoryBreakdown.find((r) => r.category === 'OPERATIONAL_EXPENSE')?.total || 0,
+    );
+
+    // 3. Get cash vs qris balance
+    const paymentSummary = await this.db
+      .select({
+        method: schema.financialTransactions.paymentMethod,
+        type: schema.financialTransactions.type,
+        total: sum(schema.financialTransactions.amount),
+      })
+      .from(schema.financialTransactions)
+      .groupBy(schema.financialTransactions.paymentMethod, schema.financialTransactions.type);
+
+    const cashIncome = Number(
+      paymentSummary.find((r) => r.method === 'CASH' && r.type === 'INCOME')?.total || 0,
+    );
+    const cashExpense = Number(
+      paymentSummary.find((r) => r.method === 'CASH' && r.type === 'EXPENSE')?.total || 0,
+    );
+    const qrisIncome = Number(
+      paymentSummary.find((r) => r.method === 'QRIS' && r.type === 'INCOME')?.total || 0,
+    );
+    const qrisExpense = Number(
+      paymentSummary.find((r) => r.method === 'QRIS' && r.type === 'EXPENSE')?.total || 0,
+    );
+
+    return {
+      totalRevenue: revenue,
+      totalCogs: cogs,
+      totalExpenses: expenses,
+      grossProfit: revenue - cogs,
+      netProfit: revenue - cogs - expenses,
+      transactionCount: await this.db
+        .select({ count: sql<number>`count(*)` })
+        .from(schema.financialTransactions)
+        .then((r) => Number(r[0].count)),
+      cashBalance: cashIncome - cashExpense,
+      qrisBalance: qrisIncome - qrisExpense,
+    };
+  }
+}

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -5,6 +5,7 @@ import * as schema from '../../db/schema';
 import { eq } from 'drizzle-orm';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { StockService } from '../stock/stock.service';
+import { FinanceService } from '../finance/finance.service';
 
 @Injectable()
 export class OrdersService {
@@ -12,6 +13,7 @@ export class OrdersService {
     @Inject(DRIZZLE_DB)
     private readonly db: NodePgDatabase<typeof schema>,
     private readonly stockService: StockService,
+    private readonly financeService: FinanceService,
   ) {}
 
   async create(dto: CreateOrderDto) {
@@ -62,6 +64,19 @@ export class OrdersService {
           referenceId: order.id,
           note: `Penjualan`,
         });
+      }
+
+      // 5. Record financial transaction if PAID
+      if (status === 'PAID') {
+        await this.financeService.recordTransaction({
+          type: 'INCOME',
+          category: 'SALES',
+          amount: totalAmount,
+          description: `Penjualan Pesanan #${order.id.slice(-6)}`,
+          paymentMethod: (dto.paymentMethod || 'CASH') as any,
+          referenceId: order.id,
+          employeeId: dto.userId, // Assuming userId is the employee who made the sale
+        }, tx);
       }
 
       return {

--- a/src/modules/purchases/purchases.service.ts
+++ b/src/modules/purchases/purchases.service.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm';
 import { CreatePurchaseDto } from './dto/create-purchase.dto';
 import { UpdatePurchaseDto } from './dto/update-purchase.dto';
 import { StockService } from '../stock/stock.service';
+import { FinanceService } from '../finance/finance.service';
 
 @Injectable()
 export class PurchasesService {
@@ -13,6 +14,7 @@ export class PurchasesService {
     @Inject(DRIZZLE_DB)
     private readonly db: NodePgDatabase<typeof schema>,
     private readonly stockService: StockService,
+    private readonly financeService: FinanceService,
   ) {}
 
 
@@ -63,6 +65,18 @@ export class PurchasesService {
             unitCost,
           });
         }
+      }
+
+      // 4. Record financial transaction if COMPLETED
+      if (dto.status === 'COMPLETED') {
+        await this.financeService.recordTransaction({
+          type: 'EXPENSE',
+          category: 'STOCK_PURCHASE',
+          amount: totalAmount,
+          description: `Pembelian Stok dari Supplier ${dto.supplierId}`,
+          paymentMethod: 'CASH', // Default for now
+          referenceId: purchase.id,
+        }, tx);
       }
 
       return {
@@ -228,6 +242,22 @@ export class PurchasesService {
             await this.syncProductVariantFromPurchaseItem(tx, id, item);
           }
         }
+      }
+
+      // Record financial transaction if changing from DRAFT to COMPLETED
+      if (!wasCompleted && willBeCompleted) {
+        const totalAmount = dto.items && dto.items.length > 0
+          ? dto.items.reduce((acc, item) => acc + item.totalCost + item.extraCosts, 0)
+          : existingPurchase.totalAmount;
+
+        await this.financeService.recordTransaction({
+          type: 'EXPENSE',
+          category: 'STOCK_PURCHASE',
+          amount: totalAmount,
+          description: `Pembelian Stok dari Supplier ${existingPurchase.supplierId}`,
+          paymentMethod: 'CASH',
+          referenceId: id,
+        }, tx);
       }
 
       return {


### PR DESCRIPTION
## Summary
- Add **Finance & Expense Tracking** system with automated financial transaction recording
- Create expense_categories, expenses, and financial_transactions tables
- Build FinanceModule (centralized ledger, P&L summary) and ExpensesModule (full CRUD for expenses)
- Auto-record INCOME when orders are PAID, EXPENSE when purchases are COMPLETED
- Seed default expense categories (Listrik & Air, Sewa Bangunan, Gaji Karyawan, etc.)

## Changes
- **Database**: 3 new tables with employee relations and proper enum types
- **Finance Service**: recordTransaction, getLedger, getSummary (P&L with revenue, COGS, expenses, net profit, cash/QRIS balance)
- **Expenses Service**: Full CRUD for expenses and categories
- **Orders Integration**: PAID orders → INCOME/SALES financial transaction
- **Purchases Integration**: COMPLETED purchases → EXPENSE/STOCK_PURCHASE financial transaction
- **Seed**: Added 7 default expense categories

Closes #29