### PR TITLE
[FEAT(orders)] Store status validation for order creation

### DIFF
--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -8,7 +8,6 @@ import {
   Query,
   UseGuards,
   Req,
-  UnauthorizedException,
 } from '@nestjs/common';
 import {
   ApiOperation,
@@ -66,7 +65,7 @@ export class OrdersController {
           name: payload.name,
           type: payload.type,
         };
-      } catch (e) {
+      } catch {
         // Token invalid, treat as guest
       }
     }

--- a/src/modules/orders/orders.module.ts
+++ b/src/modules/orders/orders.module.ts
@@ -5,6 +5,7 @@ import { StockModule } from '../stock/stock.module';
 import { PaymentModule } from '../payment/payment.module';
 import { AuthModule } from '../auth/auth.module';
 import { WhatsAppModule } from '../whatsapp/whatsapp.module';
+import { StoreSettingsModule } from '../store-settings/store-settings.module';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
@@ -14,6 +15,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     PaymentModule, 
     AuthModule,
     WhatsAppModule,
+    StoreSettingsModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException, Logger, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException, Logger, UnauthorizedException, BadRequestException } from '@nestjs/common';
 import { DRIZZLE_DB } from '../../common/database/database.module';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../../db/schema';
@@ -8,6 +8,7 @@ import { StockService } from '../stock/stock.service';
 import { FinanceService } from '../finance/finance.service';
 import { PaymentService } from '../payment/payment.service';
 import { WhatsAppService } from '../whatsapp/whatsapp.service';
+import { StoreSettingsService } from '../store-settings/store-settings.service';
 
 @Injectable()
 export class OrdersService {
@@ -20,6 +21,7 @@ export class OrdersService {
     private readonly financeService: FinanceService,
     private readonly paymentService: PaymentService,
     private readonly whatsappService: WhatsAppService,
+    private readonly storeSettingsService: StoreSettingsService,
   ) {}
 
   /**
@@ -31,11 +33,16 @@ export class OrdersService {
    */
   async create(dto: CreateOrderDto, authUserId?: string) {
     // SECURITY CHECK: WALK_IN or CASH must be authenticated (Staff POS)
-    const isQris = dto.paymentMethod === 'QRIS';
     const isStaffOrder = dto.orderType === 'WALK_IN' || dto.paymentMethod === 'CASH';
 
     if (isStaffOrder && !authUserId) {
       throw new UnauthorizedException('Transaksi CASH/WALK_IN harus dilakukan oleh petugas (login diperlukan)');
+    }
+
+    // CHECK STORE STATUS: Block order if store is closed
+    const settings = await this.storeSettingsService.getSettings();
+    if (!settings.isStoreOpen) {
+      throw new BadRequestException('Toko sedang tutup. Tidak dapat membuat pesanan saat ini.');
     }
 
     return await this.db.transaction(async (tx) => {
@@ -179,10 +186,10 @@ export class OrdersService {
           this.logger.error(`Mayar invoice generation failed: ${errorMessage}`);
           
           if (errorMessage.includes('Duplicate Request')) {
-            throw new Error('Permintaan duplikat terdeteksi. Silakan tunggu 1 menit sebelum mencoba lagi dengan nomor WhatsApp yang sama.');
+            throw new Error('Permintaan duplikat terdeteksi. Silakan tunggu 1 menit sebelum mencoba lagi dengan nomor WhatsApp yang sama.', { cause: error });
           }
           
-          throw new Error(`Gagal membuat link pembayaran QRIS: ${errorMessage}`);
+          throw new Error(`Gagal membuat link pembayaran QRIS: ${errorMessage}`, { cause: error });
         }
       }
 

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -93,10 +93,10 @@ export class PaymentService {
         this.logger.error(`Mayar API error [${response.status}]: ${JSON.stringify(data)}`);
         
         if (response.status === 429) {
-          throw new Error(`Mayar Duplicate Request: ${errorMsg}`);
+          throw new Error(`Mayar Duplicate Request: ${errorMsg}`, { cause: data });
         }
         
-        throw new Error(`Mayar API Error: ${errorMsg}`);
+        throw new Error(`Mayar API Error: ${errorMsg}`, { cause: data });
       }
 
       this.logger.log(`Mayar invoice created for order ${order.id}: ${data.data.link}`);
@@ -109,7 +109,7 @@ export class PaymentService {
         if (directPaymentUrl.includes('/invoices/')) {
           directPaymentUrl = directPaymentUrl.split('/invoices/')[0] + `/pay/${mayarTransactionId}`;
         }
-      } catch (e) {
+      } catch {
         this.logger.warn(`Failed to transform Mayar URL: ${directPaymentUrl}. Using original link.`);
       }
 
@@ -125,7 +125,7 @@ export class PaymentService {
         throw error; // Re-throw our descriptive errors
       }
       this.logger.error(`Failed to call Mayar API: ${(error as Error).message}`);
-      throw new Error(`Sistem pembayaran sedang sibuk, silakan coba lagi nanti.`);
+      throw new Error(`Sistem pembayaran sedang sibuk, silakan coba lagi nanti.`, { cause: error });
     }
   }
 


### PR DESCRIPTION
## Summary
This PR implements store-wide validation to prevent order creation and carting when the store is closed.

Closes #40 in mamuncloud/pns-server (referenced manually)

## Changes
- **Backend (OrdersService)**: Added a guard in `create()` to throw `BadRequestException` if the store is closed. Injected `StoreSettingsService`.
- **Backend (OrdersModule)**: Imported `StoreSettingsModule`.

## Verification
- Toggled store status in dashboard.
- Verified backend rejects POST /orders.
