### PR TITLE
refactor(server): decouple WhatsAppService via event-emitter

### DIFF
--- a/src/modules/orders/orders.module.ts
+++ b/src/modules/orders/orders.module.ts
@@ -4,7 +4,6 @@ import { OrdersController } from './orders.controller';
 import { StockModule } from '../stock/stock.module';
 import { PaymentModule } from '../payment/payment.module';
 import { AuthModule } from '../auth/auth.module';
-import { WhatsAppModule } from '../whatsapp/whatsapp.module';
 import { StoreSettingsModule } from '../store-settings/store-settings.module';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -14,7 +13,6 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     StockModule,
     PaymentModule,
     AuthModule,
-    WhatsAppModule,
     StoreSettingsModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -14,8 +14,9 @@ import { CreateOrderDto } from './dto/create-order.dto';
 import { StockService } from '../stock/stock.service';
 import { FinanceService } from '../finance/finance.service';
 import { PaymentService } from '../payment/payment.service';
-import { WhatsAppService } from '../whatsapp/whatsapp.service';
 import { StoreSettingsService } from '../store-settings/store-settings.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { PAYMENT_EVENTS, PaymentLinkGeneratedEvent } from '../payment/events/payment.events';
 
 @Injectable()
 export class OrdersService {
@@ -27,8 +28,8 @@ export class OrdersService {
     private readonly stockService: StockService,
     private readonly financeService: FinanceService,
     private readonly paymentService: PaymentService,
-    private readonly whatsappService: WhatsAppService,
     private readonly storeSettingsService: StoreSettingsService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   /**
@@ -196,17 +197,16 @@ export class OrdersService {
           order.paymentUrl = invoiceResult.directPaymentUrl;
 
           // Send WhatsApp notification in background
-          this.whatsappService
-            .sendPaymentLink(
-              dto.customerPhone,
-              invoiceResult.directPaymentUrl,
+          this.eventEmitter.emit(
+            PAYMENT_EVENTS.LINK_GENERATED,
+            new PaymentLinkGeneratedEvent(
               order.id,
-              totalAmount,
               dto.customerName || dto.customerPhone,
+              dto.customerPhone,
+              totalAmount,
+              invoiceResult.directPaymentUrl,
             )
-            .catch((err) =>
-              this.logger.error(`Failed to send WhatsApp notification: ${err.message}`),
-            );
+          );
         } catch (error: any) {
           const errorMessage = error.message;
           this.logger.error(`Mayar invoice generation failed: ${errorMessage}`);

--- a/src/modules/payment/events/payment.events.ts
+++ b/src/modules/payment/events/payment.events.ts
@@ -7,6 +7,17 @@ export class PaymentSatisfiedEvent {
   ) {}
 }
 
+export class PaymentLinkGeneratedEvent {
+  constructor(
+    public readonly orderId: string,
+    public readonly customerName: string,
+    public readonly customerPhone: string,
+    public readonly amount: number,
+    public readonly paymentUrl: string,
+  ) {}
+}
+
 export const PAYMENT_EVENTS = {
   SATISFIED: 'payment.satisfied',
+  LINK_GENERATED: 'payment.link_generated',
 };

--- a/src/modules/whatsapp/whatsapp.service.ts
+++ b/src/modules/whatsapp/whatsapp.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OnEvent } from '@nestjs/event-emitter';
-import { PAYMENT_EVENTS, PaymentSatisfiedEvent } from '../payment/events/payment.events';
+import { PAYMENT_EVENTS, PaymentSatisfiedEvent, PaymentLinkGeneratedEvent } from '../payment/events/payment.events';
 
 @Injectable()
 export class WhatsAppService {
@@ -69,6 +69,19 @@ _If you did not request this link, please ignore this message._`;
       event.customerName,
       event.orderId,
       orderUrl,
+    );
+  }
+
+  @OnEvent(PAYMENT_EVENTS.LINK_GENERATED)
+  async handlePaymentLinkGenerated(event: PaymentLinkGeneratedEvent) {
+    this.logger.log(`Handling payment.link_generated for order ${event.orderId}`);
+
+    await this.sendPaymentLink(
+      event.customerPhone,
+      event.paymentUrl,
+      event.orderId,
+      event.amount,
+      event.customerName,
     );
   }
 


### PR DESCRIPTION
## Description
This PR refactors `OrdersService` to decouple it from `WhatsAppService` by implementing an event-driven architecture with `@nestjs/event-emitter`.

## Changes
- Created `PaymentLinkGeneratedEvent` and `PAYMENT_EVENTS.LINK_GENERATED` constant.
- Updated `OrdersService` to inject `EventEmitter2` and emit the new event when a Mayar payment link is generated.
- Updated `WhatsAppService` to handle the `PAYMENT_EVENTS.LINK_GENERATED` event.
- Removed `WhatsAppModule` import from `OrdersModule`.

Closes #50