### PR TITLE
feat(server): implement order pagination

### DIFF
--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -18,6 +18,7 @@ import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { PaginationQueryDto } from '../../common/dto/pagination.dto';
 
 @ApiTags('Orders')
 @Controller('orders')
@@ -73,10 +74,21 @@ export class OrdersController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ANY_EMPLOYEE')
   @ApiOperation({ summary: 'Get all orders' })
-  @ApiQuery({ name: 'search', required: false, description: 'Search orders by user name' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search orders by customer name, phone, or ID' })
   @ApiResponse({ status: 200, description: 'Orders retrieved successfully' })
-  async findAll(@Query('search') search?: string) {
-    return this.ordersService.findAll(search);
+  async findAll(@Query() query: PaginationQueryDto) {
+    const { page, limit, search } = query;
+    const { data, totalItems } = await this.ordersService.findAll(page, limit, search);
+    return {
+      message: 'Berhasil mengambil semua pesanan',
+      data,
+      meta: {
+        page,
+        limit,
+        totalItems,
+        totalPages: Math.ceil(totalItems / limit),
+      },
+    };
   }
 
   @Get('public/:id')

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -9,7 +9,7 @@ import {
 import { DRIZZLE_DB } from '../../common/database/database.module';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../../db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql, or, like } from 'drizzle-orm';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { StockService } from '../stock/stock.service';
 import { FinanceService } from '../finance/finance.service';
@@ -242,8 +242,21 @@ export class OrdersService {
     return user ? { name: user.name } : null;
   }
 
-  async findAll(search?: string) {
-    const orders = await this.db.query.orders.findMany({
+  async findAll(page: number = 1, limit: number = 10, search?: string) {
+    const offset = (page - 1) * limit;
+
+    const where = search
+      ? or(
+          like(schema.orders.customerName, `%${search}%`),
+          like(schema.orders.customerPhone, `%${search}%`),
+          like(schema.orders.id, `%${search}%`),
+        )
+      : undefined;
+
+    const data = await this.db.query.orders.findMany({
+      where,
+      limit,
+      offset,
       with: {
         user: true,
         items: {
@@ -258,9 +271,16 @@ export class OrdersService {
       orderBy: (orders, { desc }) => [desc(orders.createdAt)],
     });
 
-    if (!search) return orders;
+    const totalItemsResult = await this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.orders)
+      .where(where);
+    const totalItems = Number(totalItemsResult[0].count);
 
-    return orders.filter((order) => order.user?.name?.toLowerCase().includes(search.toLowerCase()));
+    return {
+      data,
+      totalItems,
+    };
   }
 
   async findOne(id: string) {


### PR DESCRIPTION
## Changes
- Updated `OrdersController.findAll` to support pagination via query parameters.
- Updated `OrdersService.findAll` to use database-level pagination with `limit` and `offset`.
- Added search filtering by customer name, phone, and order ID at the database level.
- Standardized response format to include pagination metadata.

Closes #54