### PR TITLE
feat(events): add @Public decorator and make event endpoint public

### DIFF
--- a/src/modules/auth/decorators/public.decorator.ts
+++ b/src/modules/auth/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ExecutionContext } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/src/modules/auth/guards/roles.guard.ts
+++ b/src/modules/auth/guards/roles.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -9,6 +10,15 @@ export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
     const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -28,15 +38,12 @@ export class RolesGuard implements CanActivate {
       return false;
     }
 
-    // Role-based fallback for ANY_EMPLOYEE to handle outdated tokens
     const isEmployeeRole = ['MANAGER', 'CASHIER'].includes(user.role);
 
-    // Check if the user is an employee generally if 'ANY_EMPLOYEE' is specified
     if (requiredRoles.includes('ANY_EMPLOYEE') && (user.type === 'EMPLOYEE' || isEmployeeRole)) {
       return true;
     }
 
-    // Check specific roles (MANAGER, CASHIER, CUSTOMER)
     const hasRole = requiredRoles.some((role) => user.role === role);
 
     if (!hasRole) {

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -11,10 +11,11 @@ import { EventsService } from './events.service';
 import { CreateEventDto } from './dto/create-event.dto';
 import { AllocateEventStockDto } from './dto/allocate-event-stock.dto';
 import { ReturnEventStockDto } from './dto/return-event-stock.dto';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { Public } from '../auth/decorators/public.decorator';
 
 @ApiTags('Events')
 @Controller('events')
@@ -37,7 +38,8 @@ export class EventsController {
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Get event details' })
+  @Public()
+  @ApiOperation({ summary: 'Get event details (public for event store)' })
   findOne(@Param('id') id: string) {
     return this.eventsService.findOne(id);
   }

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -78,6 +78,13 @@ export class ProductsService {
         WHERE v."productId" = ${schema.products.id} AND v.stock > 0
       )`;
       where = where ? and(where, stockExist) : stockExist;
+    } else {
+      const notInAnyEvent = sql`NOT EXISTS (
+        SELECT 1 FROM ${schema.eventItems} ei
+        JOIN ${schema.productVariants} v ON ei."productVariantId" = v.id
+        WHERE v."productId" = ${schema.products.id}
+      )`;
+      where = where ? and(where, notInAnyEvent) : notInAnyEvent;
     }
 
     const orderByList: any[] = [];


### PR DESCRIPTION
## Summary
- Create @Public() decorator to bypass authentication on specific endpoints
- Update JwtAuthGuard and RolesGuard to check for @Public() decorator
- Make GET /events/:id endpoint publicly accessible for customer event pages

## Changes
- Added: src/modules/auth/decorators/public.decorator.ts
- Modified: src/modules/auth/guards/jwt-auth.guard.ts
- Modified: src/modules/auth/guards/roles.guard.ts
- Modified: src/modules/events/events.controller.ts

Closes #60