### PR TITLE
fix(events): make GET /events/:id publicly accessible without auth

### DIFF
--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -15,58 +15,66 @@ import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { Public } from '../auth/decorators/public.decorator';
 
 @ApiTags('Events')
 @Controller('events')
-@UseGuards(JwtAuthGuard, RolesGuard)
-@ApiBearerAuth()
 export class EventsController {
   constructor(private readonly eventsService: EventsService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MANAGER')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Create a new event (MANAGER only)' })
   create(@Body() dto: CreateEventDto) {
     return this.eventsService.create(dto);
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'List all events' })
   findAll() {
     return this.eventsService.findAll();
   }
 
   @Get(':id')
-  @Public()
   @ApiOperation({ summary: 'Get event details (public for event store)' })
   findOne(@Param('id') id: string) {
     return this.eventsService.findOne(id);
   }
 
   @Post(':id/allocate')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MANAGER')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Allocate stock to an event (MANAGER only)' })
   allocateStock(@Param('id') eventId: string, @Body() dto: AllocateEventStockDto) {
     return this.eventsService.allocateStock(eventId, dto);
   }
 
   @Post(':id/return')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MANAGER')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Return stock from an event back to warehouse (MANAGER only, supports Bulky)' })
   returnStock(@Param('id') eventId: string, @Body() dto: ReturnEventStockDto) {
     return this.eventsService.returnStock(eventId, dto);
   }
 
   @Patch(':id/status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MANAGER')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Update event status (MANAGER only)' })
   updateStatus(@Param('id') id: string, @Body('status') status: 'OPEN' | 'CLOSED') {
     return this.eventsService.updateStatus(id, status);
   }
 
   @Get(':id/report')
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('MANAGER')
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get event sales report (MANAGER only)' })
   getReport(@Param('id') id: string) {
     return this.eventsService.getReport(id);


### PR DESCRIPTION
Closes #62

## Changes

- Removed class-level `@UseGuards(JwtAuthGuard, RolesGuard)` and `@ApiBearerAuth()` from `EventsController`
- Applied guards explicitly on each protected method (`create`, `findAll`, `allocateStock`, `returnStock`, `updateStatus`, `getReport`)
- `GET /events/:id` now has no guard — unambiguously public, no token required
- Removed unused `@Public()` decorator and its import

## Why

The previous approach relied on `@Public()` overriding the class-level guard via `getAllAndOverride`. This is fragile. Explicit per-method guards are unambiguous.