### PR TITLE
feat(auth): change staff verification token to 6-digit OTP

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -58,7 +58,7 @@ export class AuthService {
       return { message: 'If you are registered, a login link will be sent.' };
     }
 
-    const token = crypto.randomBytes(32).toString('hex');
+    const token = String(Math.floor(100000 + Math.random() * 900000));
     const expiresAt = new Date();
     expiresAt.setMinutes(expiresAt.getMinutes() + 15);
 


### PR DESCRIPTION
Closes #68

## Changes
- Replace `crypto.randomBytes(32).toString('hex')` with a 6-digit numeric token (100000–999999) for staff magic link verification
- Refresh token generation is unaffected